### PR TITLE
Adds name property to WebSite Schema

### DIFF
--- a/src/Schema/Parts/WebSite.php
+++ b/src/Schema/Parts/WebSite.php
@@ -22,6 +22,10 @@ class WebSite implements SchemaPart
         $site->url(URL::makeAbsolute(Config::getSiteUrl()));
         $site->setProperty('publisher', ['@id' => SiteOwner::id()]);
         $site->setProperty('@id', self::id());
+        $name = $this->context->get('site_name')->value() ?? config('app.name') ?? '';
+        if ($name) {
+            $site->name($name);
+        }
         return $site;
     }
 


### PR DESCRIPTION
This PR adds a name property to the WebSite Schema. It attempts to use the "Website Name" set in Aardvark settings, then defaults back to the App Name from the config.