### PR TITLE
fix: constructor dynamic properties

### DIFF
--- a/src/Schema/Parts/SiteOwner.php
+++ b/src/Schema/Parts/SiteOwner.php
@@ -13,6 +13,11 @@ use WithCandour\AardvarkSeo\Schema\Parts\Contracts\SchemaPart;
 
 class SiteOwner implements SchemaPart
 {
+    /**
+     * @var array
+     */
+    public $context;
+
     public function __construct($context = [])
     {
         $this->context = $context;

--- a/src/Schema/Parts/WebPage.php
+++ b/src/Schema/Parts/WebPage.php
@@ -13,6 +13,11 @@ use WithCandour\AardvarkSeo\Schema\Parts\Contracts\SchemaPart;
 
 class WebPage implements SchemaPart
 {
+    /**
+     * @var array
+     */
+    public $context;
+
     public function __construct($context = [])
     {
         $this->context = $context;

--- a/src/Schema/Parts/WebSite.php
+++ b/src/Schema/Parts/WebSite.php
@@ -11,6 +11,11 @@ use WithCandour\AardvarkSeo\Schema\Parts\Contracts\SchemaPart;
 
 class WebSite implements SchemaPart
 {
+    /**
+     * @var array
+     */
+    public $context;
+
     public function __construct($context = [])
     {
         $this->context = $context;

--- a/src/Sitemaps/Sitemap.php
+++ b/src/Sitemaps/Sitemap.php
@@ -15,6 +15,21 @@ use WithCandour\AardvarkSeo\Blueprints\CP\SitemapSettingsBlueprint;
 class Sitemap
 {
     /**
+     * @var string
+     */
+    public $type;
+
+    /**
+     * @var string
+     */
+    public $handle;
+
+    /**
+     * @var Statamic\Sites\Site
+     */
+    public $site;
+
+    /**
      * Create a new sitemap.
      *
      * @param string $type

--- a/src/Sitemaps/Sitemap.php
+++ b/src/Sitemaps/Sitemap.php
@@ -29,6 +29,9 @@ class Sitemap
      */
     public $site;
 
+    public $route;
+    public $url;
+
     /**
      * Create a new sitemap.
      *


### PR DESCRIPTION
As of PHP 8.2, warnings are thrown when dynamic properties are used. There were a few in various constructors. This change formally declares them as public properties (since that's what they'd be when created as a dynamic property).