### PR TITLE
Fix #206 - Convert $ctx to array.

### DIFF
--- a/src/Parsers/PageDataParser.php
+++ b/src/Parsers/PageDataParser.php
@@ -161,7 +161,7 @@ class PageDataParser
     public static function generatePageTitle($data, $ctx)
     {
         if ($data->get('meta_title') && $data->get('meta_title')->raw()) {
-            return Parse::template($data->get('meta_title'), $ctx);
+            return Parse::template($data->get('meta_title'), $ctx->all());
         }
 
         if ($data->get('response_code') === 404) {


### PR DESCRIPTION
Added `->all()` to the $ctx call to convert the collection to an array as Parse::template() calls array_merge underneath. 

Fixes #206 